### PR TITLE
Use new CSS class to prevent hidden text indicator

### DIFF
--- a/app/assets/javascript/pageflow/embedded_video/page_type.js
+++ b/app/assets/javascript/pageflow/embedded_video/page_type.js
@@ -6,7 +6,7 @@ pageflow.pageType.register('embedded_video', _.extend({
   enhance: function(pageElement, configuration) {
     var that = this;
 
-    pageElement.addClass('hide_content_with_text');
+    pageElement.addClass('no_hidden_text_indicator');
 
     if (pageflow.features.has('mobile platform')) {
       pageElement.find('.close_button, .iframe_container').click(function(event) {

--- a/app/assets/stylesheets/pageflow/embedded_video.css.scss
+++ b/app/assets/stylesheets/pageflow/embedded_video.css.scss
@@ -1,19 +1,6 @@
 @include pageflow-page-type(embedded_video);
 
 .embedded_video_page {
-  /*
-    HACK: We need to set the hide_content_with_text css class on the
-    page's section, to make the menu button and hide text text
-    indicator disappear on mobile. But this also causes the content
-    to be hidden, which we undo in the following. This should be
-    decoupled in the pageflow gem.
-   */
-  .content {
-    visibility: visible !important;
-    opacity: 1 !important;
-    pointer-events: all !important;
-  }
-
   .contentText {
     margin-top: 40px;
   }

--- a/pageflow-embedded-video.gemspec
+++ b/pageflow-embedded-video.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "pageflow", "~> 0.7"
+  spec.add_runtime_dependency "pageflow", "~> 0.10.pre"
   spec.add_runtime_dependency 'i18n-js'
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Prior hack caused page content to remain visible when overview was
displayed.
