### PR TITLE
Align close button with slim player control

### DIFF
--- a/app/assets/javascript/pageflow/embedded_video/page_type.js
+++ b/app/assets/javascript/pageflow/embedded_video/page_type.js
@@ -12,7 +12,7 @@ pageflow.pageType.register('embedded_video', _.extend({
       pageElement.find('.close_button, .iframe_container').click(function(event) {
         event.stopPropagation();
         that._pauseVideo();
-        pageElement.find('.iframe_container').removeClass('show');
+        pageElement.find('.iframe_container, .close_button').removeClass('show');
         pageflow.hideText.deactivate();
       });
 
@@ -288,7 +288,7 @@ pageflow.pageType.register('embedded_video', _.extend({
   _initPlaceholderImage: function(pageElement, configuration) {
     var $div = $(document.createElement('div')),
       pageHeader = pageElement.find('.page_header'),
-      container = pageElement.find('.iframe_container'),
+      containerAndCloseButton = pageElement.find('.iframe_container, .close_button'),
       url = configuration.display_embedded_video_url;
 
     $div.addClass('iframe_overlay ' + this._urlOrigin(url));
@@ -298,7 +298,7 @@ pageflow.pageType.register('embedded_video', _.extend({
 
     $div.click(function(event) {
       event.preventDefault();
-      container.addClass('show');
+      containerAndCloseButton.addClass('show');
       pageflow.hideText.activate();
     });
   },

--- a/app/assets/stylesheets/pageflow/embedded_video.css.scss
+++ b/app/assets/stylesheets/pageflow/embedded_video.css.scss
@@ -139,11 +139,15 @@
     }
   }
 
-  .iframe_container {
-    .close_button {
-      display: none;
-    }
+  .close_button {
+    display: none;
 
+    .has_mobile_platform &.show {
+      display: block;
+    }
+  }
+
+  .iframe_container {
     .has_mobile_platform & {
       pointer-events: none;
       height: 0;
@@ -177,10 +181,6 @@
         right: 0;
         bottom: 0;
         opacity: 1;
-
-        .close_button {
-          display: block;
-        }
       }
 
       .iframe_wrapper {

--- a/app/views/pageflow/embedded_video/page.html.erb
+++ b/app/views/pageflow/embedded_video/page.html.erb
@@ -1,5 +1,10 @@
 <div class="blackLayer"></div>
 <div class="content_and_background embedded_video_page">
+  <div class="close_button" tabindex="4" title="<%= t('pageflow.public.embedded_video.leave_video') %>">
+    <div class="label">
+      <%= t('pageflow.public.close') %>
+    </div>
+  </div>
 
   <div class="backgroundArea">
     <%= background_image_div(configuration, 'background_image') %>
@@ -25,11 +30,6 @@
       </div>
     </div>
     <div class="iframe_container">
-      <div class="close_button" tabindex="4" title="<%= t('pageflow.public.embedded_video.leave_video') %>">
-        <div class="label">
-          <%= t('pageflow.public.close') %>
-        </div>
-      </div>
       <div class="iframe_wrapper"></div>
       <% if configuration['video_caption'].present? %>
         <div class="video_caption"><%= configuration['video_caption'] %></div>

--- a/pageflow-embedded-video.gemspec
+++ b/pageflow-embedded-video.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.10'
+  spec.add_runtime_dependency 'pageflow', '~> 0.11.pre'
   spec.add_runtime_dependency 'i18n-js'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 


### PR DESCRIPTION
Move close button out of content to prevent incorrect font size caused
by em font sizes set on page content.
