### PR TITLE
Do not declare bin stubs as executables in gemspec

### DIFF
--- a/pageflow-embedded-video.gemspec
+++ b/pageflow-embedded-video.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This can cause global bin stubs like `rails` to be overriden to point to this gem, which does not make sense.