### PR TITLE
Require Pageflow 12

### DIFF
--- a/pageflow-embedded-video.gemspec
+++ b/pageflow-embedded-video.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.12.pre'
+  spec.add_runtime_dependency 'pageflow', '~> 12.0.pre'
   spec.add_runtime_dependency 'i18n-js'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 


### PR DESCRIPTION
`0.12` will be released as `12.0`.