### PR TITLE
YouTube no longer supports hiding the title

### DIFF
--- a/app/assets/javascript/pageflow/embedded_video/editor/views/configuration_editor.js
+++ b/app/assets/javascript/pageflow/embedded_video/editor/views/configuration_editor.js
@@ -14,7 +14,10 @@ pageflow.ConfigurationEditorView.register('embedded_video', {
         permitHttps: true
       });
 
-      inputForProvider('youtube', this, 'embedded_video_hide_info', pageflow.CheckBoxInputView);
+      inputForProvider('youtube', this, 'embedded_video_hide_info', pageflow.CheckBoxInputView, {
+        disabled: true,
+        displayUncheckedIfDisabled: true
+      });
       inputForProvider('youtube', this, 'embedded_video_hide_controls', pageflow.CheckBoxInputView);
 
       inputForProvider('vimeo', this, 'embedded_video_hide_info', pageflow.CheckBoxInputView);

--- a/app/assets/javascript/pageflow/embedded_video/page_type.js
+++ b/app/assets/javascript/pageflow/embedded_video/page_type.js
@@ -187,8 +187,7 @@ pageflow.react.registerPageTypeWithDefaultBackground('embedded_video', {
         playerVars: {
           rel: '0',
           start: that._getVideoStartTime(url),
-          controls: configuration.embedded_video_hide_controls ? '0' : '1',
-          showinfo: configuration.embedded_video_hide_info ? '0' : '1',
+          controls: configuration.embedded_video_hide_controls ? '0' : '1'
         },
         events: {
           'onReady': function(event) {

--- a/config/locales/new/embed_parameters.de.yml
+++ b/config/locales/new/embed_parameters.de.yml
@@ -8,7 +8,7 @@ de:
           label: "Steuerelemente ausblenden"
         youtube:
           embedded_video_hide_info:
-            inline_help: "Blendet Video Titel und Player-Aktionen innerhalb des Embeds aus."
+            inline_help: "Diese Option steht für YouTube-Videos nicht zur Verfügung."
           embedded_video_hide_controls:
             inline_help: "Blendet die YouTube-Steuerelemente aus. Das Video kann per Klick gestartet und pausiert werden."
         vimeo:

--- a/config/locales/new/embed_parameters.en.yml
+++ b/config/locales/new/embed_parameters.en.yml
@@ -8,7 +8,7 @@ en:
           label: "Hide controls"
         youtube:
           embedded_video_hide_info:
-            inline_help: "Hides the video title and player actions inside the embed."
+            inline_help: "This option is not supported by YouTube video embeds."
           embedded_video_hide_controls:
             inline_help: "Hides the YouTube player controls. The video can be played and paused via click."
         vimeo:


### PR DESCRIPTION
See en version of
https://developers.google.com/youtube/player_parameters for
deprecation notice. Disable option.

REDMINE-16143