### PR TITLE
Fix loading of Pageflow::EmbeddedVideo::Configuration in production.

### DIFF
--- a/lib/pageflow/embedded_video/engine.rb
+++ b/lib/pageflow/embedded_video/engine.rb
@@ -5,7 +5,7 @@ module Pageflow
     class Engine < Rails::Engine
       isolate_namespace Pageflow::EmbeddedVideo
 
-      config.autoload_paths << File.join(config.root, 'lib')
+      config.paths.add('lib', eager_load: true)
       config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
     end
   end


### PR DESCRIPTION
Turn lib into eager load path

Files on the autoload path are no longer automatically available in
production. see pageflow-chart/lib/pageflow/chart/engine.rb