### PR TITLE
Allow assigning Configuration#supported_hosts

### DIFF
--- a/lib/pageflow/embedded_video/configuration.rb
+++ b/lib/pageflow/embedded_video/configuration.rb
@@ -4,7 +4,7 @@ module Pageflow
 
       # White list of URL prefixes (including protocol) of embedded videos.
       # @return [Array<String>]
-      attr_reader :supported_hosts
+      attr_accessor :supported_hosts
 
       def initialize
         @supported_hosts = %w[


### PR DESCRIPTION
The readme claims that this is possible. Make it so.