### PR TITLE
Enable mysql service for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ cache: bundler
 
 script:
   - bin/rspec
+
+services:
+  - mysql


### PR DESCRIPTION
No longer the default in Xenial.

REDMINE-16872